### PR TITLE
[FIX] Fix permittedInsecurePackages in nixpkgs.config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,13 @@
     let 
       cfg = {
         system = "x86_64-linux";
-        config.allowUnfree = true;
+        config = {
+          allowUnfree = true;
+          permittedInsecurePackages = [
+            "electron-19.1.9"
+            "electron-25.9.0"
+          ];
+        };
       };
 
       pkgs = import inputs.nixpkgs (cfg // {

--- a/nixos/default.nix
+++ b/nixos/default.nix
@@ -17,10 +17,6 @@
 
   nixpkgs = {
     config.allowUnfree = true;
-    config.permittedInsecurePackages = [
-      "electron-19.1.9"
-      "electron-25.9.0"
-    ];
     overlays = [
       (self: super: {
         nix-direnv = super.nix-direnv.override {


### PR DESCRIPTION
Since you import nixpkgs at flake level to provide pkgs, you need to apply the configuration here.
In your case `nixpkgs.config` is `cfg.config`